### PR TITLE
Upgrade groovy version (java 17 compat)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-xml</artifactId>
-      <version>3.0.7</version>
+      <version>3.0.9</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
After upgrading this I can compile Jenkins core on Java 17,

previously I was getting:

```
Exception in thread "main" BUG! exception in phase 'semantic analysis' in source unit 'jar:file:/Users/timja/.m2/repository/com/cloudbees/maven-license-plugin/1.9/maven-license-plugin-1.9.jar!/com/cloudbees/maven/license/htmlgen.groovy' Unsupported class file major version 61
	at org.codehaus.groovy.control.CompilationUnit$ISourceUnitOperation.doPhaseOperation(CompilationUnit.java:905)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:627)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:389)
	at groovy.lang.GroovyClassLoader.lambda$parseClass$3(GroovyClassLoader.java:332)
	at org.codehaus.groovy.runtime.memoize.StampedCommonCache.compute(StampedCommonCache.java:163)
	at org.codehaus.groovy.runtime.memoize.StampedCommonCache.getAndPut(StampedCommonCache.java:154)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:330)
	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:526)
	at groovy.lang.GroovyShell.parse(GroovyShell.java:538)
	at groovy.lang.GroovyShell.parse(GroovyShell.java:556)
	at com.cloudbees.maven.license.ProcessMojo.execute(ProcessMojo.java:160)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:957)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:289)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:193)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 61
	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:189)
	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:170)
	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:156)
	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:277)
	at org.codehaus.groovy.ast.decompiled.AsmDecompiler.parseClass(AsmDecompiler.java:81)
	at org.codehaus.groovy.control.ClassNodeResolver.findDecompiled(ClassNodeResolver.java:251)
	at org.codehaus.groovy.control.ClassNodeResolver.tryAsLoaderClassOrScript(ClassNodeResolver.java:189)
	at org.codehaus.groovy.control.ClassNodeResolver.findClassNode(ClassNodeResolver.java:169)
	at org.codehaus.groovy.control.ClassNodeResolver.resolveName(ClassNodeResolver.java:125)
	at org.codehaus.groovy.control.ResolveVisitor.resolveToOuter(ResolveVisitor.java:871)
	at org.codehaus.groovy.control.ResolveVisitor.resolve(ResolveVisitor.java:506)
	at org.codehaus.groovy.control.ResolveVisitor.visitClass(ResolveVisitor.java:1432)
	at org.codehaus.groovy.control.ResolveVisitor.startResolving(ResolveVisitor.java:262)
	at org.codehaus.groovy.control.CompilationUnit.lambda$new$16(CompilationUnit.java:738)
	at org.codehaus.groovy.control.CompilationUnit$ISourceUnitOperation.doPhaseOperation(CompilationUnit.java:901)
```

cc @jglick