### PR TITLE
Upgrade `groovy-xml` from 3.0.9 to 4.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
       <version>2.0</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-xml</artifactId>
-      <version>3.0.9</version>
+      <version>4.0.6</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
With this PR and https://github.com/jenkinsci/jenkins/pull/7293, compiling Jenkins on Java 19 is successful and `war/target/classes/META-INF/licenses.html` looks the same as before this PR.

Without this PR but with https://github.com/jenkinsci/jenkins/pull/7293, compiling Jenkins on Java 19 results in

```
[ERROR] Failed to execute goal com.cloudbees:maven-license-plugin:1.10:process (default) on project jenkins-war: Execution default of goal com.cloudbees:maven-license-plugin:1.10:process failed: startup failed:
[ERROR] General error during conversion: Unsupported class file major version 63
[ERROR] 
[ERROR] java.lang.IllegalArgumentException: Unsupported class file major version 63
[ERROR]         at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:199)
[ERROR]         at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:180)
[ERROR]         at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:166)
[ERROR]         at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:287)
[ERROR]         at org.codehaus.groovy.ast.decompiled.AsmDecompiler.parseClass(AsmDecompiler.java:81)
[ERROR]         at org.codehaus.groovy.control.ClassNodeResolver.findDecompiled(ClassNodeResolver.java:251)
[ERROR]         at org.codehaus.groovy.control.ClassNodeResolver.tryAsLoaderClassOrScript(ClassNodeResolver.java:189)
[ERROR]         at org.codehaus.groovy.control.ClassNodeResolver.findClassNode(ClassNodeResolver.java:169)
[ERROR]         at org.codehaus.groovy.control.ClassNodeResolver.resolveName(ClassNodeResolver.java:125)
[ERROR]         at org.codehaus.groovy.ast.decompiled.AsmReferenceResolver.resolveClassNullable(AsmReferenceResolver.java:57)
[ERROR]         at org.codehaus.groovy.ast.decompiled.AsmReferenceResolver.resolveClass(AsmReferenceResolver.java:44)
[ERROR]         at org.codehaus.groovy.ast.decompiled.ClassSignatureParser.configureClass(ClassSignatureParser.java:42)
[ERROR]         at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.lazyInitSupers(DecompiledClassNode.java:185)
[ERROR]         at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.isUsingGenerics(DecompiledClassNode.java:86)
[ERROR]         at org.codehaus.groovy.ast.tools.GenericsUtils.nonGeneric(GenericsUtils.java:275)
[ERROR]         at org.codehaus.groovy.ast.decompiled.MemberSignatureParser.createFieldNode(MemberSignatureParser.java:176)
[ERROR]         at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.lambda$createFieldNode$0(DecompiledClassNode.java:220)
[ERROR]         at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.createFieldNode(DecompiledClassNode.java:226)
[ERROR]         at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.lazyInitMembers(DecompiledClassNode.java:210)
[ERROR]         at org.codehaus.groovy.ast.decompiled.DecompiledClassNode.getDeclaredMethods(DecompiledClassNode.java:122)
[ERROR]         at org.codehaus.groovy.ast.ClassNode.tryFindPossibleMethod(ClassNode.java:1283)
[ERROR]         at org.codehaus.groovy.control.StaticImportVisitor.transformMethodCallExpression(StaticImportVisitor.java:251)
[ERROR]         at org.codehaus.groovy.control.StaticImportVisitor.transform(StaticImportVisitor.java:133)
[ERROR]         at org.codehaus.groovy.ast.ClassCodeExpressionTransformer.visitExpressionStatement(ClassCodeExpressionTransformer.java:108)
[ERROR]         at org.codehaus.groovy.ast.stmt.ExpressionStatement.visit(ExpressionStatement.java:40)
[ERROR]         at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitClassCodeContainer(ClassCodeVisitorSupport.java:138)
[ERROR]         at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitConstructorOrMethod(ClassCodeVisitorSupport.java:111)
[ERROR]         at org.codehaus.groovy.ast.ClassCodeExpressionTransformer.visitConstructorOrMethod(ClassCodeExpressionTransformer.java:66)
[ERROR]         at org.codehaus.groovy.control.StaticImportVisitor.visitConstructorOrMethod(StaticImportVisitor.java:108)
[ERROR]         at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitConstructor(ClassCodeVisitorSupport.java:101)
[ERROR]         at org.codehaus.groovy.ast.ClassNode.visitContents(ClassNode.java:1089)
[ERROR]         at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitClass(ClassCodeVisitorSupport.java:52)
[ERROR]         at org.codehaus.groovy.control.CompilationUnit.lambda$addPhaseOperations$3(CompilationUnit.java:209)
[ERROR]         at org.codehaus.groovy.control.CompilationUnit$IPrimaryClassNodeOperation.doPhaseOperation(CompilationUnit.java:942)
[ERROR]         at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:671)
[ERROR]         at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:635)
[ERROR]         at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:389)
[ERROR]         at groovy.lang.GroovyClassLoader.lambda$parseClass$3(GroovyClassLoader.java:332)
[ERROR]         at org.codehaus.groovy.runtime.memoize.StampedCommonCache.compute(StampedCommonCache.java:163)
[ERROR]         at org.codehaus.groovy.runtime.memoize.StampedCommonCache.getAndPut(StampedCommonCache.java:154)
[ERROR]         at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:330)
[ERROR]         at groovy.lang.GroovyShell.parseClass(GroovyShell.java:526)
[ERROR]         at groovy.lang.GroovyShell.parse(GroovyShell.java:538)
[ERROR]         at groovy.lang.GroovyShell.parse(GroovyShell.java:547)
[ERROR]         at com.cloudbees.maven.license.ProcessMojo.parseScripts(ProcessMojo.java:254)
[ERROR]         at com.cloudbees.maven.license.ProcessMojo.execute(ProcessMojo.java:139)
[ERROR]         at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
[ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:370)
[ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:351)
[ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:215)
[ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:171)
[ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:163)
[ERROR]         at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
[ERROR]         at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
[ERROR]         at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
[ERROR]         at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
[ERROR]         at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:294)
[ERROR]         at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
[ERROR]         at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
[ERROR]         at org.apache.maven.cli.MavenCli.execute(MavenCli.java:960)
[ERROR]         at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:293)
[ERROR]         at org.apache.maven.cli.MavenCli.main(MavenCli.java:196)
[ERROR]         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
[ERROR]         at java.base/java.lang.reflect.Method.invoke(Method.java:578)
[ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
[ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
[ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
[ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
```

CC @jglick