### PR TITLE
Refresh plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
-  <parent>
-    <groupId>org.kohsuke</groupId>
-    <artifactId>pom</artifactId>
-    <version>21</version>
-    <relativePath />
-  </parent>
 
   <groupId>com.cloudbees</groupId>
   <artifactId>maven-license-plugin</artifactId>
@@ -17,49 +11,100 @@
   <url>http://maven.apache.org</url>
 
   <properties>
+    <maven-plugin-tools.version>3.6.4</maven-plugin-tools.version>
+    <maven.version>3.8.6</maven.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
   
   <scm>
-    <connection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</connection>
+    <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>http://svn.sonatype.org/spice/tags/oss-parent-7/maven-license-plugin</url>
     <tag>HEAD</tag>
   </scm>
     
+  <distributionManagement>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <name>Nexus Release Repository</name>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <dependencies>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-plugin-api</artifactId>
-      <version>2.0</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
-      <version>2.0</version>
-    </dependency>
     <dependency>
       <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-xml</artifactId>
       <version>4.0.6</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>${maven-plugin-tools.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.10.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.4.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.2.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-plugin-plugin</artifactId>
-        <version>2.5.1</version>
+        <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <goalPrefix>maven-license-plugin</goalPrefix>
+          <doclint>all,-missing</doclint>
+          <locale>en_US</locale>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>${maven-plugin-tools.version}</version>
+        <configuration>
+          <goalPrefix>license</goalPrefix>
         </configuration>
         <executions>
           <execution>
@@ -71,25 +116,121 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>3.0.0-M6</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>cloudbees-release</releaseProfiles>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.13</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>sonatype-nexus-staging</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
     </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.4.1</version>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <id>jdk-8-and-below</id>
+      <activation>
+        <jdk>(,1.8]</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+              <testSource>1.8</testSource>
+              <testTarget>1.8</testTarget>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <source>1.8</source>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk-9-and-above</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <release>8</release>
+              <testRelease>8</testRelease>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <release>8</release>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>cloudbees-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <phase>verify</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/src/main/java/com/cloudbees/maven/license/CompleterDelegate.java
+++ b/src/main/java/com/cloudbees/maven/license/CompleterDelegate.java
@@ -10,8 +10,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static java.util.Collections.*;
-
 /**
  * Base class for completer scripts that define convenience methods.
  *
@@ -80,7 +78,7 @@ public class CompleterDelegate {
             throw error;
         }
 
-        dependency.setLicenses(singletonList(to));
+        dependency.setLicenses(Collections.singletonList(to));
     }
 
     /**
@@ -97,10 +95,10 @@ public class CompleterDelegate {
      * From the multi-licensed modules, accept one of them.
      */
     public void accept(String name) {
-        List<License> licenses = new ArrayList<License>(dependency.getLicenses());
+        List<License> licenses = new ArrayList<>(dependency.getLicenses());
         for (License lic : licenses) {
             if (lic.getName().equals(name)) {
-                dependency.setLicenses(new ArrayList<License>(Arrays.asList(lic)));
+                dependency.setLicenses(Collections.singletonList(lic));
                 return;
             }
         }


### PR DESCRIPTION
Updates all dependencies to the latest version, including adapting to recent Maven plugin API changes. Since Kohsuke's parent POM is no longer maintained and the Jenkins parent POM publishes to the Jenkins Artifactory rather than Maven Central, I have chosen to remove any parent POM from this project. While this does entail a little duplication, it simplifies the management of this non-standard component by only pulling in exactly what we need. The ugliness of a solution that duplicates the code merely mirrors the ugliness of the deployment setup and GitHub organization of this repository, which does not follow our standard conventions.

### Testing done

I ensured that Javadocs could be built by running (locally) `mvn clean verify -Pcloudbees-release -Dgpg.skip` on both Java 8 and Java 11.

I tested this on Java 19 with a Jenkins core build and verified that the generated license information was the same before and after this PR. Note that to adapt to Maven API changes the core build needed this patch:

```groovy
@@ -565,7 +565,11 @@ THE SOFTWARE.
                 // add Winstone since we are bundling it.
                 def d = project.dependencies.find { it.artifactId=="winstone" };
                 def a = mojo.artifactFactory.createProjectArtifact(d.groupId,d.artifactId,d.version);
-                def p = mojo.projectBuilder.buildFromRepository(a, project.getRemoteArtifactRepositories(), mojo.localRepository)
+                def buildingRequest = new org.apache.maven.project.DefaultProjectBuildingRequest(mojo.session.projectBuildingRequest)
+                buildingRequest.remoteRepositories = project.remoteArtifactRepositories
+                buildingRequest.localRepository = mojo.localRepository
+                buildingRequest.processPlugins = false // improve performance
+                def p = mojo.projectBuilder.build(a, buildingRequest).project
                 models.put(a,p);
```

CC @jglick