### PR TITLE
Revert `developerConnection` change from #12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
   
   <scm>
     <connection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</connection>
-    <developerConnection>scm:git:https://github.com/cloudbees/maven-license-plugin.git</developerConnection>
+    <developerConnection>scm:git:git@github.com:cloudbees/maven-license-plugin.git</developerConnection>
     <url>https://github.com/cloudbees/maven-license-plugin</url>
     <tag>maven-license-plugin-1.14</tag>
   </scm>


### PR DESCRIPTION
After #12

```
[INFO] Executing: /bin/sh -c cd '…/maven-license-plugin' && 'git' 'push' 'https:********@github.com/cloudbees/maven-license-plugin.git' 'refs/heads/master:refs/heads/master'
[INFO] Working directory: …/maven-license-plugin
Password for 'https://git@github.com':   C-c C-c
```

despite HTTPS normally working fine. Apparently it decides that the username should be `git`. :shrug: MRP
