### PR TITLE
Update `groovy-xml` for Java 21 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-xml</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.12</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
I was investigating into the prerequisites of compiling Jenkins core with Java 21, and noticed, bumping `groovy-xml` does the trick already for this maven plugin.

Could we get a release of this, once merged @jglick?